### PR TITLE
Upgrade prost and prost-build to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,11 @@ authors = ["Boncheol Gu <boncheol.gu@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-bytes = "0.4"
 failure = "0.1"
 heck = "0.3"
 log = "0.4"
-prost = "0.5"
-prost-build = "0.5"
+prost = "0.6"
+prost-build = "0.6"
 protobuf-gen-derive = { path = "protobuf-gen-derive" }
 protobuf-gen-extract = { path = "protobuf-gen-extract" }
 syn = { version = "1.0", features = ["visit"] }

--- a/lib_tests/Cargo.toml
+++ b/lib_tests/Cargo.toml
@@ -5,11 +5,10 @@ authors = ["Boncheol Gu <boncheol.gu@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-bytes = "0.4"
 failure = "0.1"
 proptest = "0.9"
 proptest-derive = "0.1.1"
-prost = "0.5"
+prost = "0.6"
 protobuf-gen = { path = ".." }
 
 [build-dependencies]

--- a/protobuf-gen-derive/src/convert.rs
+++ b/protobuf-gen-derive/src/convert.rs
@@ -323,7 +323,7 @@ impl Extract for ConversionGenerator {
 
                     let mut buffer = Vec::new();
                     r.read_to_end(&mut buffer)?;
-                    let proxy = #proxy::#ident::from_i32(prost::Message::decode(buffer)?)
+                    let proxy = #proxy::#ident::from_i32(prost::Message::decode(&buffer[..])?)
                         .ok_or_else(|| format_err!("invalid \"{}\"", stringify!(#ident)))?;
                     proxy.try_into()
                 }
@@ -357,7 +357,7 @@ impl ConversionGenerator {
 
                     let mut buffer = Vec::new();
                     r.read_to_end(&mut buffer)?;
-                    let proxy: #proxy::#ident = prost::Message::decode(buffer)?;
+                    let proxy: #proxy::#ident = prost::Message::decode(&buffer[..])?;
                     proxy.try_into()
                 }
             }


### PR DESCRIPTION
In prost 0.6, `prost::Message::decode` takes as its argument `bytes::buf::Buf` instead of `bytes::buf::IntoBuf`.